### PR TITLE
fix: license in package.json to be spdx compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "licenses": [
     {
-      "type": "Apache 2.0",
+      "type": "Apache-2.0",
       "url": "https://github.com/shakyshane/easy-logger/blob/master/LICENSE"
     }
   ],


### PR DESCRIPTION
The license/licenses key in the package.json [must be SPDX compatible](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license).
The String "Apache 2.0" is not a valid [SPDX identifier](https://spdx.org/licenses/). The correct string is "Apache 2.0".

This can cause errors e.g. in projects that have license checks. For me this caused a nx-workspace update to fail.
